### PR TITLE
install cover and cover-coveralls separately for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,17 @@ env:
     - RACKET_DIR=~/racket
   matrix:
     - RACKET_VERSION=6.1.1
+    - RACKET_VERSION=6.2
+    - RACKET_VERSION=6.2.1
+    - RACKET_VERSION=6.3
+    - RACKET_VERSION=6.4
+    - RACKET_VERSION=6.5
 
 before_install:
   - git clone https://github.com/greghendershott/travis-racket.git ../travis-racket
   - cat ../travis-racket/install-racket.sh | bash
   - export PATH="${RACKET_DIR}/bin:${PATH}"
+  - raco pkg install --deps search-auto cover cover-coveralls
 
 install: raco pkg install --deps search-auto $TRAVIS_BUILD_DIR # install dependencies
 

--- a/info.rkt
+++ b/info.rkt
@@ -5,3 +5,8 @@
 (define build-deps '("scribble-lib"
                      "rackunit-lib"
                      "racket-doc"))
+
+(define cover-omit-paths
+  '(#rx".*\\.scrbl"
+    #rx"info\\.rkt"
+    ))

--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,6 @@
 
 (define collection 'multi)
 (define deps '("base" "rackunit-lib"))
-(define build-deps '("cover"
-                     "scribble-lib"
+(define build-deps '("scribble-lib"
                      "rackunit-lib"
                      "racket-doc"))


### PR DESCRIPTION
This makes it no longer necessary for this to depend on the cover package outside of travis builds.

Fixes https://github.com/jackfirth/predicates/issues/1
